### PR TITLE
Revert "add required contentdir yum vars for centos74"

### DIFF
--- a/roles/qemu-kvm-ev/tasks/main.yml
+++ b/roles/qemu-kvm-ev/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
- - name: ensure yum vars contentdir is present with proper value
-   copy:
-     content: 'centos'
-     dest: /etc/yum/vars/contentdir
-   when: ansible_os_family == "RedHat"
-
 - name: install the centos-release-qemu-ev repo
   yum:
     name: centos-release-qemu-ev


### PR DESCRIPTION
Reverts platform9/autodeploy#26 as it’s currently breaking 