### PR TITLE
fixed k82-cluster-attach role

### DIFF
--- a/roles/k8s-cluster-attach/tasks/main.yml
+++ b/roles/k8s-cluster-attach/tasks/main.yml
@@ -29,7 +29,7 @@
   uri:
     url: "https://{{ctrl_ip}}/qbert/v1/clusters/{{cluster_uuid}}/attach"
     method: POST
-    body: "{{host_id.stdout.strip()}}"
+    body: "['{{host_id.stdout.strip()}}']"
     body_format: json
     validate_certs: False
     headers:


### PR DESCRIPTION
Fixed k82-cluster-attach role: HTML body format was invalid for post to Qbert API