### PR TITLE
added '-o|--oscli' flag to INSTALL (install/configure OpenStack CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pf9-autodeploy.conf
+pf9-openstack.rc
 platform9-install-redhat.sh
 group_vars/all.yml
 lib/INSTALL.log

--- a/INSTALL
+++ b/INSTALL
@@ -184,7 +184,7 @@ install_awx() {
   fi
 }
 
-# install_oscli <ctrl-hostname> <region>
+# install_oscli <ctrl-hostname> <region> <tenant> <username> <password>
 install_oscli() {
   echo "[ Installing OpenStack CLI ]"
   echo "--> Installation Log: ${log}"
@@ -195,15 +195,7 @@ install_oscli() {
 
   # configure pf9-openstack.rc
   echo "--> Building pf9-openstack.rc"
-  osrc_file=${basedir}/pf9-openstack.rc
-  if [ -r ${osrc_file} ]; then rm -f ${osrc_file}; touch ${osrc_file}; fi
-  echo "export OS_AUTH_URL=https://${1}/keystone/v3" >> ${osrc_file}
-  echo "export OS_IDENTITY_API_VERSION=3" >> ${osrc_file}
-  echo "export OS_REGION_NAME='${2}'" >> ${osrc_file}
-  echo "export OS_USERNAME='${du_username}'" >> ${osrc_file}
-  echo "export OS_PASSWORD='${du_password}'" >> ${osrc_file}
-  echo "export OS_PROJECT_NAME='${3}'" >> ${osrc_file}
-  echo "export OS_PROJECT_DOMAIN_ID=${OS_PROJECT_DOMAIN_ID:-'default'}" >> ${osrc_file}
+  update_openstack_rc ${1} ${2} ${3} ${4} ${5}
 
   # source rc file
   source ${osrc_file}
@@ -326,7 +318,7 @@ install_prereqs() {
 ################################################################################
 ## main
 ################################################################################
-# incliude libraries
+# include libraries
 source ${basedir}/lib/config_util.sh
 source ${basedir}/lib/utility.sh
 
@@ -460,7 +452,7 @@ ctrl_ip=${tmp_ip:1:((${#tmp_ip}-2))}
 
 ## install openstack cli
 if [ ${flag_oscli} -eq 1 ]; then
-  install_oscli ${ctrl_hostname} ${du_region} ${du_tenant}
+  install_oscli ${ctrl_hostname} ${du_region} ${du_tenant} ${du_username} ${du_password}
   exit 0
 fi
 

--- a/INSTALL
+++ b/INSTALL
@@ -24,11 +24,11 @@ awxcli_repo=https://github.com/ansible/tower-cli.git
 flag_setup=0
 flag_prereqs=0
 flag_ui=0
+flag_oscli=0
 flag_dbinit=0
 flag_skip_prereqs=0
 flag_awx_restart=0
 flag_autoregister=0
-flag_nginx_init=0
 extra_vars=""
 awx_pf9_user="pf9"
 awx_pf9_password="Pl@tform9"
@@ -43,10 +43,10 @@ usage() {
   echo "-i|--installPrereqs        : install pre-requisites and exit"
   echo "-s|--setup                 : run setup and exit"
   echo "-u|--ui                    : install web UI (Ansible AWX)"
+  echo "-o|--oscli                 : install OpenStack CLI"
   echo "-r|--restartAwx            : restart AWX"
   echo "-d|--dbinit                : initialize AWX database"
   echo "-x|--dbExport <exportFile> : use <exportFile> for dbinit"
-  echo "-n|--nginx-init            : configure nginx (pf9-express config)"
   echo "-c|--config <configFile>   : use custom configuration file"
   echo "-e|--extra-vars <string>   : ansible extra-vars <name=val,...>"
   echo "-b|--bypassPrereqs         : bypass pre-requisites"
@@ -182,9 +182,68 @@ install_awx() {
   if [ ${elapsedTime} -ge ${TIMEOUT} ]; then
     assert "*** TIMEOUT EXCEEDED *** waiting to connect to awx"
   fi
+}
 
-  # configure nginx
-  if [ ${flag_nginx_init} -eq 1 ]; then nginx_init; fi
+# install_oscli <ctrl-hostname> <region>
+install_oscli() {
+  echo "[ Installing OpenStack CLI ]"
+  echo "--> Installation Log: ${log}"
+  if [ $# -ne 3 ]; then
+    echo "install_oscli(): missing arguments (expected 3; got $#)"
+    return 1
+  fi
+
+  # configure pf9-openstack.rc
+  echo "--> Building pf9-openstack.rc"
+  osrc_file=${basedir}/pf9-openstack.rc
+  if [ -r ${osrc_file} ]; then rm -f ${osrc_file}; touch ${osrc_file}; fi
+  echo "export OS_AUTH_URL=https://${1}/keystone/v3" >> ${osrc_file}
+  echo "export OS_IDENTITY_API_VERSION=3" >> ${osrc_file}
+  echo "export OS_REGION_NAME='${2}'" >> ${osrc_file}
+  echo "export OS_USERNAME='${du_username}'" >> ${osrc_file}
+  echo "export OS_PASSWORD='${du_password}'" >> ${osrc_file}
+  echo "export OS_PROJECT_NAME='${3}'" >> ${osrc_file}
+  echo "export OS_PROJECT_DOMAIN_ID=${OS_PROJECT_DOMAIN_ID:-'default'}" >> ${osrc_file}
+
+  # source rc file
+  source ${osrc_file}
+
+  # install openstack cli packages (CentOS)
+  if [ "${platform}" == "centos" ]; then
+    echo -n "--> Installing Package Dependencies"
+    for pkg in gcc openssl-devel python-pip python-wheel python-virtualenv python-virtualenvwrapper; do
+      echo -n "${pkg} "
+      rpm -q ${pkg} > /dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        sudo yum -y install ${pkg} > ${log} 2>&1
+        if [ $? -ne 0 ]; then
+          echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"
+          tail -10 ${log}; exit 1
+        fi
+      fi
+    done
+    echo
+
+    echo "--> Configuring Python Virtual Environment"
+    if [ ! -r /usr/bin/virtualenvwrapper.sh ]; then assert "missing script: /usr/bin/virtualenvwrapper.sh"; fi
+    source /usr/bin/virtualenvwrapper.sh
+    export WORKON_HOME=$HOME/.virtenvs
+    mkvirtualenv os_cli > ${log} 2>&1
+
+    echo "--> Upgrading PIP"
+    pip install pip --upgrade > ${log} 2>&1
+
+    echo "--> Installing OpenStack CLI"
+    pip install --upgrade --requirement \
+        https://raw.githubusercontent.com/platform9/support-locker/master/openstack-clients/requirements.txt \
+        --constraint http://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt > ${log} 2>&1
+  fi
+
+  # install openstack cli packages (Ubuntu)
+  if [ "${platform}" == "ubuntu" ]; then
+    assert "Not Implemented (for platform = ${platform})"
+  fi
+
 }
 
 install_prereqs() {
@@ -287,11 +346,11 @@ while [ $# -gt 0 ]; do
   -u|--ui)
     flag_ui=1
     ;;
+  -o|--oscli)
+    flag_oscli=1
+    ;;
   -d|--dbinit)
     flag_dbinit=1
-    ;;
-  -n|--nginx-init)
-    flag_nginx_init=1
     ;;
   -r|--restartAwx)
     flag_awx_restart=1
@@ -383,8 +442,27 @@ if [ ${flag_ui} -eq 1 -o ${flag_dbinit} -eq 1 ]; then
   exit 0
 fi
 
-## validate target
-if [ -z "${target}" ]; then usage; fi
+## lookup configuration values from config file
+du_username=$(grep ^os_username ${pf9_config} | cut -d \| -f2)
+du_password=$(grep ^os_password ${pf9_config} | cut -d \| -f2)
+nova_dns_domain=$(grep ^nova_dns_domain ${pf9_config} | cut -d \| -f2)
+du_region=$(grep ^os_region ${pf9_config} | cut -d \| -f2)
+du_tenant=$(grep ^os_tenant ${pf9_config} | cut -d \| -f2)
+proxy_url=$(grep ^proxy_url ${pf9_config} | cut -d \| -f2)
+
+## append proxy_url to extra_args
+if [ "${proxy_url}" != "-" ]; then extra_vars="${extra_vars} proxy_url=${proxy_url}"; fi
+
+## assign/validate ctrl_ip from config file and resolve IP for ctrl_hostname
+ctrl_hostname=$(grep ^du_url ${pf9_config} | cut -d \| -f2 | cut -d \/ -f3)
+tmp_ip=$(ping -c 1 ${ctrl_hostname} | grep PING | cut -d ' ' -f3)
+ctrl_ip=${tmp_ip:1:((${#tmp_ip}-2))}
+
+## install openstack cli
+if [ ${flag_oscli} -eq 1 ]; then
+  install_oscli ${ctrl_hostname} ${du_region} ${du_tenant}
+  exit 0
+fi
 
 ## display banner
 banner
@@ -397,19 +475,8 @@ ansible_version=$(ansible --version | head -1 | cut -d ' ' -f2 | cut -d . -f1-2)
 echo "--> ansible_version = ${ansible_version}"
 if (( ! $(bc <<< "$ansible_version >= $min_ansible_version") )); then assert "Ansible ${min_ansible_version} or greater is required"; fi
 
-## lookup configuration values from config file
-du_username=$(grep ^os_username ${pf9_config} | cut -d \| -f2)
-du_password=$(grep ^os_password ${pf9_config} | cut -d \| -f2)
-nova_dns_domain=$(grep ^nova_dns_domain ${pf9_config} | cut -d \| -f2)
-proxy_url=$(grep ^proxy_url ${pf9_config} | cut -d \| -f2)
-
-## append proxy_url to extra_args
-if [ "${proxy_url}" != "-" ]; then extra_vars="${extra_vars} proxy_url=${proxy_url}"; fi
-
-## assign/validate ctrl_ip from config file and resolve IP for ctrl_hostname
-ctrl_hostname=$(grep ^du_url ${pf9_config} | cut -d \| -f2 | cut -d \/ -f3)
-tmp_ip=$(ping -c 1 ${ctrl_hostname} | grep PING | cut -d ' ' -f3)
-ctrl_ip=${tmp_ip:1:((${#tmp_ip}-2))}
+## validate target
+if [ -z "${target}" ]; then usage; fi
 
 ## toggle auto-regsister flag
 if [ ${flag_autoregister} -eq 1 ]; then

--- a/INSTALL
+++ b/INSTALL
@@ -204,7 +204,7 @@ install_oscli() {
 
   # install openstack cli packages (CentOS)
   if [ "${platform}" == "centos" ]; then
-    echo -n "--> Installing Package Dependencies"
+    echo -n "--> Installing Package Dependencies: "
     for pkg in gcc openssl-devel python-pip python-wheel python-virtualenv python-virtualenvwrapper; do
       echo -n "${pkg} "
       rpm -q ${pkg} > /dev/null 2>&1

--- a/INSTALL
+++ b/INSTALL
@@ -7,6 +7,8 @@
 # initialize variables
 basedir=$(dirname $0)
 min_ansible_version="2.2"
+oscli_version=pike
+oscli_rc_file=${basedir}/pf9-openstack.rc
 inventory=${basedir}/inventory/hosts
 autodeplopy_script=${basedir}/pf9-autodeploy.yml
 platform=""
@@ -188,7 +190,7 @@ install_awx() {
 install_oscli() {
   echo "[ Installing OpenStack CLI ]"
   echo "--> Installation Log: ${log}"
-  if [ $# -ne 3 ]; then
+  if [ $# -ne 5 ]; then
     echo "install_oscli(): missing arguments (expected 3; got $#)"
     return 1
   fi
@@ -198,7 +200,7 @@ install_oscli() {
   update_openstack_rc ${1} ${2} ${3} ${4} ${5}
 
   # source rc file
-  source ${osrc_file}
+  source ${oscli_rc_file}
 
   # install openstack cli packages (CentOS)
   if [ "${platform}" == "centos" ]; then
@@ -228,7 +230,7 @@ install_oscli() {
     echo "--> Installing OpenStack CLI"
     pip install --upgrade --requirement \
         https://raw.githubusercontent.com/platform9/support-locker/master/openstack-clients/requirements.txt \
-        --constraint http://raw.githubusercontent.com/openstack/requirements/stable/newton/upper-constraints.txt > ${log} 2>&1
+        --constraint http://raw.githubusercontent.com/openstack/requirements/stable/${oscli_version}/upper-constraints.txt > ${log} 2>&1
   fi
 
   # install openstack cli packages (Ubuntu)

--- a/lib/config_util.sh
+++ b/lib/config_util.sh
@@ -3,16 +3,15 @@
 update_openstack_rc() {
   if [ $# -ne 5 ]; then return 1; fi
 
-  local osrc_file=${basedir}/pf9-openstack.rc
-  if [ -r ${osrc_file} ]; then rm -f ${osrc_file}; touch ${osrc_file}; fi
+  if [ -r ${oscli_rc_file} ]; then rm -f ${oscli_rc_file}; touch ${oscli_rc_file}; fi
 
-  echo "export OS_AUTH_URL=https://${1}/keystone/v3" >> ${osrc_file}
-  echo "export OS_IDENTITY_API_VERSION=3" >> ${osrc_file}
-  echo "export OS_REGION_NAME='${2}'" >> ${osrc_file}
-  echo "export OS_USERNAME='${4}'" >> ${osrc_file}
-  echo "export OS_PASSWORD='${5}'" >> ${osrc_file}
-  echo "export OS_PROJECT_NAME='${3}'" >> ${osrc_file}
-  echo "export OS_PROJECT_DOMAIN_ID=${OS_PROJECT_DOMAIN_ID:-'default'}" >> ${osrc_file}
+  echo "export OS_AUTH_URL=https://${1}/keystone/v3" >> ${oscli_rc_file}
+  echo "export OS_IDENTITY_API_VERSION=3" >> ${oscli_rc_file}
+  echo "export OS_REGION_NAME='${2}'" >> ${oscli_rc_file}
+  echo "export OS_USERNAME='${4}'" >> ${oscli_rc_file}
+  echo "export OS_PASSWORD='${5}'" >> ${oscli_rc_file}
+  echo "export OS_PROJECT_NAME='${3}'" >> ${oscli_rc_file}
+  echo "export OS_PROJECT_DOMAIN_ID=${OS_PROJECT_DOMAIN_ID:-'default'}" >> ${oscli_rc_file}
 }
 
 update_template() {

--- a/lib/config_util.sh
+++ b/lib/config_util.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+update_openstack_rc() {
+  if [ $# -ne 5 ]; then return 1; fi
+
+  local osrc_file=${basedir}/pf9-openstack.rc
+  if [ -r ${osrc_file} ]; then rm -f ${osrc_file}; touch ${osrc_file}; fi
+
+  echo "export OS_AUTH_URL=https://${1}/keystone/v3" >> ${osrc_file}
+  echo "export OS_IDENTITY_API_VERSION=3" >> ${osrc_file}
+  echo "export OS_REGION_NAME='${2}'" >> ${osrc_file}
+  echo "export OS_USERNAME='${4}'" >> ${osrc_file}
+  echo "export OS_PASSWORD='${5}'" >> ${osrc_file}
+  echo "export OS_PROJECT_NAME='${3}'" >> ${osrc_file}
+  echo "export OS_PROJECT_DOMAIN_ID=${OS_PROJECT_DOMAIN_ID:-'default'}" >> ${osrc_file}
+}
+
 update_template() {
   if [ $# -ne 2 ]; then return 1; fi
 

--- a/openstack-cli
+++ b/openstack-cli
@@ -7,12 +7,53 @@
 # initialize variables
 basedir=$(dirname $0)
 os_cli=/home/centos/.virtenvs/os_cli/bin/openstack
+os_cmd=""
 rc_file=${basedir}/pf9-openstack.rc
+pf9_config=${basedir}/pf9-autodeploy.conf
+pf9_custom_configFile=""
 
 usage() {
-  echo "Usage: `basename $0` <command> [-h|--help]"
+  echo "Usage: `basename $0` [Args] [<command>]"
+  echo -e "\nArgs (Optional):\n"
+  echo "-c|--config <configFile> : use custom configuration file"
+  echo -e "-h|--help                : display this message\n"
   exit 1
 }
+
+# include libraries
+source ${basedir}/lib/config_util.sh
+
+# process arguments
+while [ $# -gt 0 ]; do
+  case ${1} in
+  -h|--help)
+    usage ;;
+  -c|--config)
+    if [ $# -lt 2 ]; then usage; fi
+    pf9_custom_configFile=${2}
+    shift 2
+    ;;
+  *)
+    os_cmd=${1}
+    ;;
+  esac
+done
+
+## use custom config (if specified on commandline)
+if [ -n "${pf9_custom_configFile}" ]; then pf9_config=${pf9_custom_configFile}; fi
+
+# validate config file
+if [ ! -r ${pf9_config} ]; then assert "could not find auto-deploy config file (looked in ${pf9_config})"; fi
+
+## lookup configuration values from config file
+ctrl_hostname=$(grep ^du_url ${pf9_config} | cut -d \| -f2 | cut -d \/ -f3)
+du_region=$(grep ^os_region ${pf9_config} | cut -d \| -f2)
+du_tenant=$(grep ^os_tenant ${pf9_config} | cut -d \| -f2)
+du_username=$(grep ^os_username ${pf9_config} | cut -d \| -f2)
+du_password=$(grep ^os_password ${pf9_config} | cut -d \| -f2)
+
+# build rc file
+update_openstack_rc ${ctrl_hostname} ${du_region} ${du_tenant} ${du_username} ${du_password}
 
 # source rc file
 if [ ! -r ${rc_file} ]; then assert "could not find openstack rc file (looked in ${rc_file})"; fi
@@ -21,17 +62,5 @@ source ${rc_file}
 # validate openstack cli is installed
 if [ ! -r ${os_cli} ]; then assert "could not find openstack cli (looked in ${os_cli})"; fi
 
-# process arguments
-while [ $# -gt 0 ]; do
-  case ${1} in
-  -h|--help)
-    usage ;;
-  *)
-    eval ${os_cli} ${1}
-    exit $?
-    ;;
-  esac
-done
-
-eval ${os_cli}
+eval ${os_cli} ${os_cmd}
 exit $?

--- a/openstack-cli
+++ b/openstack-cli
@@ -1,0 +1,37 @@
+#!/bin/bash
+################################################################################
+## Platform9 Openstack CLI Utility
+## Copyright(c) 2018 Platform9 Systems, Inc.
+################################################################################
+
+# initialize variables
+basedir=$(dirname $0)
+os_cli=/home/centos/.virtenvs/os_cli/bin/openstack
+rc_file=${basedir}/pf9-openstack.rc
+
+usage() {
+  echo "Usage: `basename $0` <command> [-h|--help]"
+  exit 1
+}
+
+# source rc file
+if [ ! -r ${rc_file} ]; then assert "could not find openstack rc file (looked in ${rc_file})"; fi
+source ${rc_file}
+
+# validate openstack cli is installed
+if [ ! -r ${os_cli} ]; then assert "could not find openstack cli (looked in ${os_cli})"; fi
+
+# process arguments
+while [ $# -gt 0 ]; do
+  case ${1} in
+  -h|--help)
+    usage ;;
+  *)
+    eval ${os_cli} ${1}
+    exit $?
+    ;;
+  esac
+done
+
+eval ${os_cli}
+exit $?

--- a/openstack-cli
+++ b/openstack-cli
@@ -7,6 +7,7 @@
 # initialize variables
 basedir=$(dirname $0)
 os_cli=/home/centos/.virtenvs/os_cli/bin/openstack
+oscli_rc_file=${basedir}/pf9-openstack.rc
 os_cmd=""
 rc_file=${basedir}/pf9-openstack.rc
 pf9_config=${basedir}/pf9-autodeploy.conf


### PR DESCRIPTION
Added installer flag to install/configure OpenStack CLI:

# ./INSTALL -o
[ Installing OpenStack CLI ]
--> Installation Log: /tmp/pf9-INSTALL.log
--> Building pf9-openstack.rc
--> Installing Package Dependenciesgcc openssl-devel python-pip python-wheel python-virtualenv python-virtualenvwrapper
--> Configuring Python Virtual Environment
--> Upgrading PIP
--> Installing OpenStack CLI

# ./openstack-cli
(openstack) host list
+--------------------------------------+-------------+----------+
| Host Name                            | Service     | Zone     |
+--------------------------------------+-------------+----------+
| dwpf9-kvm-01.platform9.net.novalocal | conductor   | internal |
| dwpf9-kvm-01.platform9.net.novalocal | network     | internal |
| dwpf9-kvm-01.platform9.net.novalocal | consoleauth | internal |
| dwpf9-kvm-01.platform9.net.novalocal | scheduler   | internal |
| 601db253-d02c-4a25-b6d8-0cb35d900144 | compute     | nova     |
| 83516c3d-984a-4168-8765-2607ca0c395a | compute     | nova     |
| 7d4ff7d3-b3ff-41f1-bdac-7bbeb1eb2fa5 | compute     | nova     |
| 478eeedd-8770-4d7f-ae9c-5e466da7513f | compute     | nova     |
+--------------------------------------+-------------+----------+