### PR TITLE
added pre_hook, post_hook, and network_hook (user-defined roles)

### DIFF
--- a/pf9-autodeploy.yml
+++ b/pf9-autodeploy.yml
@@ -11,6 +11,12 @@
     - name: install python2
       raw: if [ -e /etc/lsb-release -a ! -e /usr/bin/python ]; then (apt -y update && apt install -y python-minimal); fi
 
+# Run pre_hook (if exists)
+- hosts: all
+  become: true
+  roles:
+    - pre-hook
+
 # Openstack Hypervisor Nodes
 - hosts: hypervisors
   become: true
@@ -21,6 +27,7 @@
     - pf9-hostagent
     - qemu-kvm-ev
     - neutron-prerequisites
+    - { role: "network-hook", when: autoreg == "on"}
     - { role: "map-role", rolename: "pf9-ostackhost-neutron", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-neutron-base", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-ceilometer", when: autoreg == "on" and ceilometer == "on" }
@@ -71,4 +78,10 @@
     - { role: "map-role", rolename: "pf9-kube", when: autoreg == "on" }
     - { role: "wait-for-convergence", when: autoreg == "on" }
     - { role: "k8s-cluster-attach", k8s_node_type: "worker", when: autoreg == "on" }
+
+# Run post_hook (if it exists)
+- hosts: all
+  become: true
+  roles:
+    - post-hook
 

--- a/roles/network-hook/tasks/main.yml
+++ b/roles/network-hook/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- debug: msg="running network_hook():"

--- a/roles/network-hook/tasks/main.yml
+++ b/roles/network-hook/tasks/main.yml
@@ -1,3 +1,24 @@
 ---
+##########################################################################################################
+## network_hook:
+## 
+## This hook is a user-defined script for site-specific network configurations.
+## Feel free to modify as needed for your environment.
+##########################################################################################################
 
 - debug: msg="running network_hook():"
+
+##
+## By default, auto-deploy creates an interface named "bond0" and adds it to an OVS bridge named "br-pf9".
+##
+- name: check if OVS bridge already exists
+  shell: "ifconfig -a | grep ^br-pf9 > /dev/null 2>&1; if [ $? -eq 0 ]; then echo 'exists'; else echo 'not-exist'; fi"
+  register: ovs_bridge_check
+
+- name: Set br-pf9 port as bond0
+  openvswitch_port:
+    bridge: br-pf9
+    port: bond0
+    state: present
+  when: ovs_bridge_check.stdout.strip() == "not-exist"
+

--- a/roles/neutron-prerequisites/tasks/main.yml
+++ b/roles/neutron-prerequisites/tasks/main.yml
@@ -27,10 +27,3 @@
     state: present
   when: ovs_bridge_check.stdout.strip() == "not-exist"
 
-- name: Set br-pf9 port as bond0
-  openvswitch_port:
-    bridge: br-pf9
-    port: bond0
-    state: present
-  when: ovs_bridge_check.stdout.strip() == "not-exist" and network_hook_check.stat.exists == false
-

--- a/roles/neutron-prerequisites/tasks/main.yml
+++ b/roles/neutron-prerequisites/tasks/main.yml
@@ -21,15 +21,16 @@
   shell: "ifconfig -a | grep ^br-pf9 > /dev/null 2>&1; if [ $? -eq 0 ]; then echo 'exists'; else echo 'not-exist'; fi"
   register: ovs_bridge_check
 
-- block: 
-  - name: Create required OVS bridges
-    openvswitch_bridge:
-      bridge: br-pf9
-      state: present
-
-  - name: Set br-pf9 port as bond0
-    openvswitch_port:
-      bridge: br-pf9
-      port: bond0
-      state: present
+- name: Create required OVS bridges
+  openvswitch_bridge:
+    bridge: br-pf9
+    state: present
   when: ovs_bridge_check.stdout.strip() == "not-exist"
+
+- name: Set br-pf9 port as bond0
+  openvswitch_port:
+    bridge: br-pf9
+    port: bond0
+    state: present
+  when: ovs_bridge_check.stdout.strip() == "not-exist" and network_hook_check.stat.exists == false
+

--- a/roles/post-hook/tasks/main.yml
+++ b/roles/post-hook/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- debug: msg="running post_hook():"

--- a/roles/pre-hook/tasks/main.yml
+++ b/roles/pre-hook/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- debug: msg="running pre_hook():"


### PR DESCRIPTION
Added 3 hooks to Auto-Deploy:
* pre_hook
* network_hook
* post_hook

Each hook is a stub playbook that exists in the roles/ directory that a customer can modify as needed to extend Auto-Deploy.  For example, if a customer wanted to change the way networking is configured, they can add their own code to roles/network-hook/tasks/main.yml, or if they want to run a role before/after auto-deploy they can modify roles/pre-hook and roles/post-hook, respectively.