### PR TITLE
added pre-flight-checks role (with one check)

### DIFF
--- a/group_vars/cinder.yml
+++ b/group_vars/cinder.yml
@@ -3,3 +3,7 @@
 
 cinder_volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
 cinder_backend_name: cinder-volumes
+
+# variables for pre-flight-checks
+cinder_image_conversion_cache: /opt/pf9/pf9-cindervolume-base/lib/python2.7/site-packages/cinder/conversion
+cinder_image_cache_min_free_space: 20000000

--- a/group_vars/hypervisors.yml
+++ b/group_vars/hypervisors.yml
@@ -15,6 +15,3 @@ neutron_ovs_enable_tunneling: "False"
 neutron_ovs_net_type: vlan
 ceilometer_kvm_instance_disk_path: /opt/pf9/data/instances/
 
-# variables for pre-flight-checks
-cinder_image_conversion_cache: /opt/pf9/pf9-cindervolume-base/lib/python2.7/site-packages/cinder/conversion
-cinder_image_cache_min_free_space: 20000000

--- a/group_vars/hypervisors.yml
+++ b/group_vars/hypervisors.yml
@@ -14,3 +14,7 @@ neutron_ovs_bridge_mappings: "external:br-pf9"
 neutron_ovs_enable_tunneling: "False"
 neutron_ovs_net_type: vlan
 ceilometer_kvm_instance_disk_path: /opt/pf9/data/instances/
+
+# variables for pre-flight-checks
+cinder_image_conversion_cache: /opt/pf9/pf9-cindervolume-base/lib/python2.7/site-packages/cinder/conversion
+cinder_image_cache_min_free_space: 20000000

--- a/pf9-autodeploy.yml
+++ b/pf9-autodeploy.yml
@@ -11,8 +11,20 @@
     - name: install python2
       raw: if [ -e /etc/lsb-release -a ! -e /usr/bin/python ]; then (apt -y update && apt install -y python-minimal); fi
 
-# Run pre_hook (if exists)
-- hosts: all
+# Run pre_flight_checks
+- hosts:
+    - hypervisors
+    - k8s-master
+    - k8s-worker
+  become: true
+  roles:
+    - pre-flight-checks
+
+# Run pre_hook
+- hosts:
+    - hypervisors
+    - k8s-master
+    - k8s-worker
   become: true
   roles:
     - pre-hook
@@ -79,8 +91,11 @@
     - { role: "wait-for-convergence", when: autoreg == "on" }
     - { role: "k8s-cluster-attach", k8s_node_type: "worker", when: autoreg == "on" }
 
-# Run post_hook (if it exists)
-- hosts: all
+# Run post_hook
+- hosts:
+    - hypervisors
+    - k8s-master
+    - k8s-worker
   become: true
   roles:
     - post-hook

--- a/roles/pre-flight-checks/tasks/main.yml
+++ b/roles/pre-flight-checks/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- debug: msg="running pre_flight_checks():"
+
+###########################################################################################
+## validate free space in filesystem that the Cinder temp directory lives on
+###########################################################################################
+- block:
+  - debug: msg="Validate minimum free space for cinder_image_conversion_cache (at least {{cinder_image_cache_min_free_space}} KBytes)"
+  - name: get free space for cinder_image_conversion_cache
+    shell: "df -k {{cinder_image_conversion_cache}} | tail -1 | awk '{print $2}'"
+    register: cinder_cache_free_space
+  - debug: var=cinder_cache_free_space
+  
+  - fail:
+      msg="Insufficient free space in {{cinder_image_conversion_cache}} (mimimum required = {{cinder_image_cache_min_free_space}})"
+    when: cinder_cache_free_space.stdout.strip() < cinder_image_cache_min_free_space
+  when: inventory_hostname in groups['cinder']


### PR DESCRIPTION
Added pre-flight-checks role with one check:
* validates that there is enough free space in the filesystem hosting the Cinder image conversion directory. 
NOTE 1: runs on Cinder nodes only.
NOTE 2: the minimal value is defined in group_vars/cinder.yml but can be overridden via "INSTALL -e <extra-vars>"