### PR TITLE
added feature to control uid/gid for pf9 service account

### DIFF
--- a/lib/hosts.tpl
+++ b/lib/hosts.tpl
@@ -5,8 +5,6 @@
 [all:vars]
 ansible_ssh_pass=Pl@tform9
 ansible_sudo_pass=Pl@tform9
-pf9_uid=1001
-pf9_gid=1001
 
 ################################################################################################
 ## Optional Settings

--- a/lib/hosts.tpl
+++ b/lib/hosts.tpl
@@ -5,6 +5,8 @@
 [all:vars]
 ansible_ssh_pass=Pl@tform9
 ansible_sudo_pass=Pl@tform9
+pf9_uid=1001
+pf9_gid=1001
 
 ################################################################################################
 ## Optional Settings

--- a/lib/setupd.rpm
+++ b/lib/setupd.rpm
@@ -1,1 +1,0 @@
-../roles/map-role/files/setupd.rpm

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -36,16 +36,35 @@
   with_items: "{{ dns_resolvers }}"
   when: manage_resolvers == True
 
-- name: Check if pf9 user already installed
-  shell: "grep pf9 /etc/passwd > /dev/null 2>&1; if [ $? -ne 0 ]; then echo 'not-installed'; fi"
+- name: Check if pf9 user already exists
+  shell: "grep pf9 /etc/passwd > /dev/null 2>&1; if [ $? -ne 0 ]; then echo 'not-exist'; else echo 'exists'; fi"
   register: pf9_account_status
 
+# pf9 user does not exist
 - block:
   - name: create /opt/pf9 directory
     file:
       path: /opt/pf9
       state: directory
       mode: 0755
+
+  - block:
+    - name: Check if custom uid is already in-use
+      shell: "awk -F : '{print $3}' /etc/passwd | grep {{pf9_uid}}; if [ $? -ne 0 ]; then echo 'not-exist'; else echo 'exists'; fi"
+      register: pf9_uid_status
+
+    - fail: msg="Custom UID {{pf9_uid}} already in-use"
+      when: pf9_uid_status.stdout.strip() == "exists"
+    when: pf9_uid is defined
+
+  - block:
+    - name: Check if custom gid is already in-use
+      shell: "awk -F : '{print $3}' /etc/group | grep {{pf9_gid}}; if [ $? -ne 0 ]; then echo 'not-exist'; else echo 'exists'; fi"
+      register: pf9_gid_status
+
+    - fail: msg="Custom GID {{pf9_gid}} already in-use"
+      when: pf9_gid_status.stdout.strip() == "exists"
+    when: pf9_gid is defined
 
   # create Platform9 service account
   - name: create Platform9 service group (pf9group)
@@ -64,7 +83,7 @@
       create_home: True
       groups: pf9group
     when: pf9_uid is defined
-  when: pf9_account_status is defined and pf9_account_status == "not-installed"
+  when: pf9_account_status is defined and pf9_account_status.stdout.strip() == "not-exist"
 
 - include: redhat.yml
   when: ansible_os_family == "RedHat"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -36,6 +36,41 @@
   with_items: "{{ dns_resolvers }}"
   when: manage_resolvers == True
 
-- debug: msg="OS Family = {{ansible_os_family}}"
+- name: Check if pf9 user already installed
+  shell: "grep pf9 /etc/passwd > /dev/null 2>&1; if [ $? -ne 0 ]; then echo 'not-installed'; fi"
+  register: pf9_account_status
+
+- block:
+  - name: create /opt/pf9 directory
+    file:
+      path: /opt/pf9
+      state: directory
+      mode: 0755
+
+  - set_fact: 
+      pf9_uid: 1001
+    when: pf9_uid is undefined
+
+  - set_fact: 
+      pf9_gid: 1001
+    when: pf9_gid is undefined
+
+  # create Platform9 service account
+  - name: create Platform9 service group (pf9group)
+    group:
+      name: pf9group
+      gid: "{{pf9_gid}}"
+      state: present
+
+  - name: create Platform9 service account (pf9)
+    user:
+      name: pf9
+      shell: /bin/bash
+      uid: "{{pf9_uid}}"
+      home: /opt/pf9/home
+      create_home: True
+      groups: pf9group
+  when: pf9_account_status is defined and pf9_account_status == "not-installed"
+
 - include: redhat.yml
   when: ansible_os_family == "RedHat"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -47,20 +47,13 @@
       state: directory
       mode: 0755
 
-  - set_fact: 
-      pf9_uid: 1001
-    when: pf9_uid is undefined
-
-  - set_fact: 
-      pf9_gid: 1001
-    when: pf9_gid is undefined
-
   # create Platform9 service account
   - name: create Platform9 service group (pf9group)
     group:
       name: pf9group
       gid: "{{pf9_gid}}"
       state: present
+    when: pf9_gid is defined
 
   - name: create Platform9 service account (pf9)
     user:
@@ -70,6 +63,7 @@
       home: /opt/pf9/home
       create_home: True
       groups: pf9group
+    when: pf9_uid is defined
   when: pf9_account_status is defined and pf9_account_status == "not-installed"
 
 - include: redhat.yml


### PR DESCRIPTION
Added 2 new inventory variables (to lib/hosts.tpl): 
* pf9_uid=1001
* pf9_gid=1001

And updated the roles/common to use these values when adding the 'pf9' user and the 'pf9group' group. 

NOTE: previously, the user/group was created by the pf9-hostagent installer.