### PR TITLE
Modifying logic to apply when br-pf9 exists

### DIFF
--- a/roles/network-hook/tasks/main.yml
+++ b/roles/network-hook/tasks/main.yml
@@ -26,4 +26,4 @@
     bridge: br-pf9
     port: bond0
     state: present
-  when: ovs_bridge_check.stdout.strip() == "not-exist"
+  when: ovs_bridge_check.stdout.strip() == "exists"


### PR DESCRIPTION
Fixes issue #96, which was introduced in pull request #36. This fix is critical given any customer deployment without this today will likely be broken.